### PR TITLE
Add priorityclass system-cluster-critical to operator

### DIFF
--- a/component/emergency-credentials-controller.jsonnet
+++ b/component/emergency-credentials-controller.jsonnet
@@ -36,6 +36,18 @@ local deploymentPatch = {
   },
 } + com.makeMergeable(params.controller_deployment_patch);
 
+local setPriorityClass = {
+  patch: |||
+    - op: add
+      path: "/spec/template/spec/priorityClassName"
+      value: "system-cluster-critical"
+  |||,
+  target: {
+    kind: 'Deployment',
+    name: 'emergency-credentials-controller-controller-manager',
+  },
+};
+
 local patch = function(p) {
   patch: std.manifestJsonMinified(p),
 };
@@ -60,6 +72,7 @@ com.Kustomization(
       patch(removeUpstreamNamespace),
       patch(removeUpstreamAlerts),
       patch(deploymentPatch),
+      setPriorityClass,
     ],
     labels+: [
       {

--- a/tests/golden/defaults/emergency-credentials-controller/emergency-credentials-controller/apps_v1_deployment_emergency-credentials-controller-controller-manager.yaml
+++ b/tests/golden/defaults/emergency-credentials-controller/emergency-credentials-controller/apps_v1_deployment_emergency-credentials-controller-controller-manager.yaml
@@ -101,6 +101,7 @@ spec:
           capabilities:
             drop:
             - ALL
+      priorityClassName: system-cluster-critical
       securityContext:
         runAsNonRoot: true
         seccompProfile:


### PR DESCRIPTION
Ensure this component has precedence over user deployed workload.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
